### PR TITLE
Release for version 1.6.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@peoplepower/webcore",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@peoplepower/webcore",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peoplepower/webcore",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Client JS/TS SDK for People Power App API",
   "keywords": [
     "WebCore",

--- a/src/data/services/systemPropertiesService.ts
+++ b/src/data/services/systemPropertiesService.ts
@@ -56,6 +56,24 @@ export class SystemPropertiesService extends BaseService {
   }
 
   /**
+   * Gets branded idle timeouts
+   * @returns {Promise<{[brand: string]: number} | undefined>}
+   */
+  public getBrandedIdleTimeoutConfig(): Promise<BrandedIdleTimeoutConfig | undefined> {
+    return this.systemAndUserPropertiesApi.getSystemProperty('ppc.web.brandedIdleTimeout')
+      .then(str => {
+        if (str) {
+          try {
+            return JSON.parse(str);
+          } catch (e) {
+            this.logger.error(`Unable to parse as JSON 'ppc.web.brandedIdleTimeout' System Property: ${str}`, e);
+          }
+        }
+        return undefined;
+      });
+  }
+
+  /**
    * Get current user system of measurements
    * @returns {Promise<'metric' | 'us'>}
    */
@@ -87,4 +105,11 @@ export enum SystemOfMeasurement {
    * United States customary units / imperial units
    */
   Us = 'us',
+}
+
+/**
+ * Brand (organization.brand) to timout (in seconds) map
+ */
+export interface BrandedIdleTimeoutConfig {
+  [brand: string]: number;
 }


### PR DESCRIPTION
- Update for WEB-45, branded session timeout.
- Update version to 1.6.9