### PR TITLE
Part of WEB-56; Update device model data model for historical params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@peoplepower/webcore",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@peoplepower/webcore",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peoplepower/webcore",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Client JS/TS SDK for People Power App API",
   "keywords": [
     "WebCore",

--- a/src/data/api/app/deviceModels/getDeviceModelsApiResponse.ts
+++ b/src/data/api/app/deviceModels/getDeviceModelsApiResponse.ts
@@ -151,6 +151,14 @@ export interface GetDeviceModelsApiResponse extends ApiResponseBase {
         };
 
         /**
+         * Historical-only parameters.
+         * Parameters not listed in current device measurements.
+         */
+        historicalParams?: Array<{
+          name: string;
+        }>;
+
+        /**
          * Dictionary of brands that are supported as a bundle.
          * Each brand contains a bundle story ID, and an array of model ids with the number of devices included in bundle
          */


### PR DESCRIPTION
Add "historicalParams" array into "displayInfo" of the Device Model data model notation. This explicit notation used for device parameters which is not returned by Current Device Measurements API, and instead presented only in device measurements history.