### PR TITLE
Security fix for version 3.1.8

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,7 +34,7 @@ jobs:
     # Update .npmrc for security
     - name: Configure .npmrc for security
       run: echo "block-exotic-subdeps=true" >> .npmrc
-    - run: echo "minimum-release-age=10080" >> .npmrc
+    - run: echo "min-release-age=7" >> .npmrc
 
     # Install dependencies and build the package
     - name: Install dependencies and run build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     # Update .npmrc for security
     - name: Configure .npmrc for security
       run: echo "block-exotic-subdeps=true" >> .npmrc
-    - run: echo "minimum-release-age=10080" >> .npmrc
+    - run: echo "min-release-age=7" >> .npmrc
 
     # Install dependencies and build the package
     - name: Install dependencies and run build

--- a/.npmrc.example
+++ b/.npmrc.example
@@ -2,5 +2,5 @@
 //npm.pkg.github.com/:_authToken=GITHUB_TOKEN
 
 engine-strict=true
-minimum-release-age=10080
+min-release-age=7
 block-exotic-subdeps=true


### PR DESCRIPTION
This pull request updates the configuration for dependency management in both the workflow files and the `.npmrc.example` file to use a new setting name and value for the minimum release age. The changes ensure consistency across configuration files and align with updated naming conventions.

Dependency configuration updates:

* Changed the `.npmrc` setting from `minimum-release-age=10080` to `min-release-age=7` in `.github/workflows/package.yml` and `.github/workflows/tests.yml` to match the new naming convention and value format. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L37-R37) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL38-R38)
* Updated `.npmrc.example` to use `min-release-age=7` instead of `minimum-release-age=10080` for clarity and consistency with workflow files.