### PR TITLE
Release for 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
--
+
+## [3.3.2] - 2026-08-20
+
+### Added
+- Files service `getPublicMedia` method to get branded public media (logo) URLs
 
 ## [3.3.1] - 2026-07-31
 
@@ -98,7 +102,8 @@ and this project adheres to [Semantic Versioning].
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
 <!-- Versions -->
-[unreleased]: https://github.com/peoplepower/webcore/compare/3.3.1...HEAD
+[unreleased]: https://github.com/peoplepower/webcore/compare/3.3.2...HEAD
+[3.3.2]: https://github.com/peoplepower/webcore/compare/3.3.1..3.3.2
 [3.3.1]: https://github.com/peoplepower/webcore/compare/3.3.0..3.3.1
 [3.3.0]: https://github.com/peoplepower/webcore/compare/3.2.1..3.3.0
 [3.2.1]: https://github.com/peoplepower/webcore/compare/3.2.0..3.2.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peoplepower/webcore",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Client JS/TS SDK for Care Daily Cloud API",
   "type": "module",
   "keywords": [
@@ -33,7 +33,7 @@
     "url": "https://github.com/peoplepower/webcore.git"
   },
   "license": "Apache-2.0",
-  "packageManager": "pnpm@11.17.0",
+  "packageManager": "pnpm@11.21.0",
   "engines": {
     "node": ">=22.13.0 <23.0.0"
   },

--- a/src/data/dal/publicMediaDal.ts
+++ b/src/data/dal/publicMediaDal.ts
@@ -1,0 +1,16 @@
+import { Dal } from './dal';
+import { injectable } from '../../modules/common/di';
+
+/**
+ * Data access layer for publicly available media files hosted outside of the Cloud API (CDN).
+ *
+ * It is intentionally created without any interceptor:
+ * there is no API key to send to a third party host, no cloud base url to resolve
+ * and no API response envelope to unwrap - plain files are served here.
+ */
+@injectable('PublicMediaDal')
+export class PublicMediaDal extends Dal {
+  constructor() {
+    super();
+  }
+}

--- a/src/data/services/filesService.ts
+++ b/src/data/services/filesService.ts
@@ -4,13 +4,29 @@ import { ApplicationFilesApi } from '../api/app/applicationFiles/applicationFile
 import { AppFileType, GetApplicationFilesApiResponse } from '../api/app/applicationFiles/getApplicationFilesApiResponse';
 import { GetApplicationFileUrlApiResponse } from '../api/app/applicationFiles/getApplicationFileUrlApiResponse';
 import { CloudConfigService } from './cloudConfigService';
+import { PublicMediaDal } from '../dal/publicMediaDal';
 import { Path } from '../../modules/common/path';
 import * as qs from 'qs';
+
+const publicMediaBaseUrl = 'https://webmedia.peoplepowerco.com/';
+
+/**
+ * Directory each public media type is stored in, relative to the public media base url.
+ */
+const publicMediaPaths: { [type in PublicMediaType]: string } = {
+  logo: '/logos/',
+};
+
+/**
+ * Default timeout (ms) of the public media file existence check request.
+ */
+const publicMediaCheckTimeout = 10000;
 
 @injectable('FilesService')
 export class FilesService extends BaseService {
   @inject('ApplicationFilesApi') protected readonly applicationFilesApi!: ApplicationFilesApi;
   @inject('CloudConfigService') protected readonly cloudConfigService!: CloudConfigService;
+  @inject('PublicMediaDal') protected readonly publicMediaDal!: PublicMediaDal;
 
   /**
    * Returns a list of application files filtered by query parameters.
@@ -102,4 +118,107 @@ export class FilesService extends BaseService {
     }
     return this.applicationFilesApi.getApplicationFileUrl(fileId, params);
   }
+
+  /**
+   * Builds URL of a publicly available branded media file.
+   *
+   * No Cloud API and no authorization is involved here: files are served by the public media host
+   * (`https://webmedia.peoplepowerco.com/` by default) and the URL is composed from the naming convention:
+   * `{baseUrl}/logos/{brand}-logo[-vertical][-white][@2x].{svg|png}`.
+   *
+   * Examples for the `peoplepower` brand:
+   * - `https://webmedia.peoplepowerco.com/logos/peoplepower-logo.svg` (defaults)
+   * - `https://webmedia.peoplepowerco.com/logos/peoplepower-logo@2x.png` (`fileFormat: 'PNG'`)
+   * - `https://webmedia.peoplepowerco.com/logos/peoplepower-logo-vertical.svg` (`orientation: 'portrait'`)
+   * - `https://webmedia.peoplepowerco.com/logos/peoplepower-logo-vertical-white@2x.png` (all of the above + `white`)
+   *
+   * NOTE about `params.checkExistence`: the public media host does not send any `Access-Control-Allow-Origin`
+   * header and rejects preflight requests, so the existence check can only succeed where the same origin policy
+   * is not enforced (Node.js, React Native, server side rendering). In a browser the check request is blocked by
+   * CORS for every URL, existing or not, therefore it is disabled by default. To validate a URL from a browser
+   * render it in an `<img>` tag (image loading is not restricted by CORS) and handle the `error` event.
+   *
+   * @param {string} brand Brand name, e.g. `peoplepower`.
+   * @param {PublicMediaType} mediaType Type of the media file. Only `logo` is supported for now.
+   * @param [params] Request parameters.
+   * @param {PublicMediaFileFormat} [params.fileFormat] File format, `SVG` by default.
+   * @param {PublicMediaOrientation} [params.orientation] Media orientation, `landscape` by default.
+   * @param {boolean} [params.white] Get the white (inverted) version of the media file.
+   * @param {boolean} [params.checkExistence] Check that the file is really available before resolving the URL
+   *     and reject if it is not. Disabled by default, see the CORS note above.
+   * @param {number} [params.timeout] Timeout (ms) of the existence check request, 10000 by default.
+   * @param {string} [params.baseUrl] Public media host to use instead of the default one.
+   *
+   * @returns {Promise<string>} Full URL of the media file.
+   */
+  getPublicMedia(
+    brand: string,
+    mediaType: PublicMediaType,
+    params?: {
+      fileFormat?: PublicMediaFileFormat;
+      orientation?: PublicMediaOrientation;
+      white?: boolean;
+      checkExistence?: boolean;
+      timeout?: number;
+      baseUrl?: string;
+    },
+  ): Promise<string> {
+    if (!brand || !brand.trim()) {
+      return this.reject(`Brand can not be empty [${brand}].`);
+    }
+    if (!mediaType || !publicMediaPaths.hasOwnProperty(mediaType)) {
+      return this.reject(`Unsupported public media type [${mediaType}].`);
+    }
+
+    const fileFormat: PublicMediaFileFormat = params?.fileFormat || 'SVG';
+    if (fileFormat !== 'SVG' && fileFormat !== 'PNG') {
+      return this.reject(`Unsupported public media file format [${fileFormat}].`);
+    }
+
+    const orientation: PublicMediaOrientation = params?.orientation || 'landscape';
+    if (orientation !== 'landscape' && orientation !== 'portrait') {
+      return this.reject(`Unsupported public media orientation [${orientation}].`);
+    }
+
+    const fileName =
+      encodeURIComponent(brand.trim()) +
+      `-${mediaType}` +
+      (orientation === 'portrait' ? '-vertical' : '') +
+      (params?.white ? '-white' : '') +
+      (fileFormat === 'PNG' ? '@2x.png' : '.svg');
+
+    const mediaUrl = Path.Combine(params?.baseUrl || publicMediaBaseUrl, publicMediaPaths[mediaType], fileName);
+
+    if (!params?.checkExistence) {
+      return Promise.resolve(mediaUrl);
+    }
+
+    return this.publicMediaDal
+      .head<void>(mediaUrl, {
+        noAuth: true,
+        timeout: params.timeout || publicMediaCheckTimeout,
+      })
+      .then(() => mediaUrl)
+      .catch((error) => {
+        const status = error?.response?.status;
+        return this.reject(
+          `Public media file is not available [${mediaUrl}]${status ? ` (status ${status})` : ''}: ${error?.message || error}`,
+        );
+      });
+  }
 }
+
+/**
+ * Type of a publicly available media file. Only brand logos are supported for now.
+ */
+export type PublicMediaType = 'logo';
+
+/**
+ * File format of a publicly available media file.
+ */
+export type PublicMediaFileFormat = 'SVG' | 'PNG';
+
+/**
+ * Orientation of a publicly available media file.
+ */
+export type PublicMediaOrientation = 'landscape' | 'portrait';


### PR DESCRIPTION
This pull request introduces a new feature to the `FilesService` that allows clients to retrieve branded public media (such as logo URLs) hosted outside the Cloud API, along with supporting infrastructure. It also updates the package version and dependency information.

**New Public Media Feature:**

* Added a new `getPublicMedia` method to `FilesService` for building and optionally validating URLs to branded public media files (currently only logos) hosted on a public CDN, with support for file format, orientation, color variant, and existence checks.
* Introduced a new data access layer class `PublicMediaDal` for handling requests to public media resources without authentication or API envelope.

**Versioning and Dependency Updates:**

* Bumped package version to `3.3.2` and updated the package manager version in `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L36-R36)
* Updated `CHANGELOG.md` to document the new feature and version, and adjusted version comparison links. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL9-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL101-R106)